### PR TITLE
Update ServiceCertStore.psm1 to fix a typo

### DIFF
--- a/src/servicecerts-pwsh/ServiceCertStore/ServiceCertStore.psm1
+++ b/src/servicecerts-pwsh/ServiceCertStore/ServiceCertStore.psm1
@@ -46,7 +46,7 @@ function Get-ServiceCertificates {
     $store = Get-ServiceCertificateStore $ServiceName $StoreName
     try {
         foreach ($c in $store.Certificates) {
-            if ($Thumbprint -and -not ($c.$Thumbprint -in $Thumbprint)) {
+            if ($Thumbprint -and -not ($c.Thumbprint -in $Thumbprint)) {
                 continue
             }
             if ($Subject -and -not ($c.Subject -in $Subject)) {


### PR DESCRIPTION
The function Get-ServiceCertificate has a typo when using the filter thumbprint.